### PR TITLE
Use ts parser for vue templates.

### DIFF
--- a/src/extract.js
+++ b/src/extract.js
@@ -68,7 +68,7 @@ function preprocessScript(data, type) {
       const vueTemplate = compileTemplate({source: vueFile.template.content});
       contents.push({
         content: vueTemplate.code,
-        lang: 'js',
+        lang: 'ts',
         lineOffset: vueFile.template.loc.start.line,
         template: true
       });


### PR DESCRIPTION
The typescript parser seems to be more stable and filters out non literals passed to gettext out more reliably. There is probably no reason to have the non-typescript parser at all as typescript is a superset of javascript, but let's not be too invasive for now.